### PR TITLE
Configure semantic-release commit message line length limits

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -20,5 +20,8 @@ export default {
     ],
     "subject-case": [2, "always", "lower-case"],
     "header-max-length": [2, "always", 100],
+    // Disable body/footer line length limits for semantic-release notes
+    "body-max-line-length": [0, "always", Infinity],
+    "footer-max-line-length": [0, "always", Infinity],
   },
 };

--- a/progress.txt
+++ b/progress.txt
@@ -16,3 +16,9 @@ Each entry documents: date, feature, decisions, files changed, tests, and concer
 - Changes: Configured semantic-release with changelog/npm/git plugins, added commitlint with conventional commits, set up husky commit-msg hook, created CI/release workflows, wrote comprehensive README and AGENT.md
 - Decisions: Used pnpm-compatible husky v9, semantic-release v24 with standard plugins, commitlint strict mode for subject-case
 - Issues: None
+
+[2026-02-05] #5 chore: Configure semantic-release commit message line length limits
+- Files: commitlint.config.js
+- Changes: Disabled body-max-line-length and footer-max-line-length rules to allow semantic-release notes and Co-Authored-By footers
+- Decisions: Set rules to severity 0 (disabled) rather than increasing limit to avoid arbitrary caps
+- Issues: None


### PR DESCRIPTION
## Summary
- Disabled commitlint body and footer line length limits by setting `body-max-line-length` and `footer-max-line-length` rules to `[0, 'always', Infinity]`
- This allows semantic-release to generate commit messages with long `Co-Authored-By` footers and detailed descriptions without triggering commitlint validation errors

## Test Plan
- [ ] Verify commitlint accepts long body/footer lines: `echo "test: message with long body" | pnpm commitlint`
- [ ] Confirm CI pipeline passes on merge to main
- [ ] Verify semantic-release can generate commits without line length errors

Closes #5


---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*