### PR TITLE
Configure npm publishing to use @rotorsoft namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# contui
+# @rotorsoft/contui
 
+[![npm version](https://img.shields.io/npm/v/@rotorsoft/contui.svg)](https://www.npmjs.com/package/@rotorsoft/contui)
 [![CI](https://github.com/Rotorsoft/contui/actions/workflows/ci.yml/badge.svg)](https://github.com/Rotorsoft/contui/actions/workflows/ci.yml)
 [![Release](https://github.com/Rotorsoft/contui/actions/workflows/release.yml/badge.svg)](https://github.com/Rotorsoft/contui/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
-  "name": "contui",
+  "name": "@rotorsoft/contui",
   "version": "1.0.0",
   "description": "Terminal UI for macOS native container management",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
     "contui": "dist/index.js"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "tsc",

--- a/progress.txt
+++ b/progress.txt
@@ -22,3 +22,9 @@ Each entry documents: date, feature, decisions, files changed, tests, and concer
 - Changes: Disabled body-max-line-length and footer-max-line-length rules to allow semantic-release notes and Co-Authored-By footers
 - Decisions: Set rules to severity 0 (disabled) rather than increasing limit to avoid arbitrary caps
 - Issues: None
+
+[2026-02-05] #7 chore: Configure npm publishing to use @rotorsoft namespace
+- Files: package.json, README.md
+- Changes: Updated package name to @rotorsoft/contui, added publishConfig.access=public for scoped public publishing, added npm version badge to README
+- Decisions: Scoped packages require explicit public access; semantic-release npm plugin handles scoped packages without config changes
+- Issues: None - CI npm token must have @rotorsoft scope permissions


### PR DESCRIPTION
## Summary
- Updated package name from `contui` to `@rotorsoft/contui` to publish under the @rotorsoft npm scope
- Added `publishConfig.access: "public"` to ensure the scoped package is publicly accessible on npm
- Updated README badge to reference the new scoped package name

## Test Plan
- [ ] Run `pnpm pack` and verify the generated tarball uses the scoped package name
- [ ] Run `npm publish --dry-run` to confirm the package would publish with correct naming
- [ ] After merge, verify the package appears at https://www.npmjs.com/package/@rotorsoft/contui
- [ ] Confirm semantic-release successfully publishes under the @rotorsoft scope

Closes #7


---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*